### PR TITLE
「仕様変更」の抽出対応、および分類の日本語化

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,4 @@
+bugs-label=### バグ修正
+enhancement-label=### 機能追加
+breaking-label=### 仕様変更
+pr-label=### その他変更

--- a/env-set.bat
+++ b/env-set.bat
@@ -1,2 +1,2 @@
 @echo off
-PATH=C:\Ruby25-x64\bin;C:\Ruby25\bin;%PATH%
+PATH=C:\Ruby24-x64\bin;C:\Ruby24\bin;%PATH%

--- a/env-set.bat
+++ b/env-set.bat
@@ -1,2 +1,2 @@
 @echo off
-PATH=C:\Ruby24-x64\bin;C:\Ruby24\bin;%PATH%
+PATH=C:\Ruby25-x64\bin;C:\Ruby25\bin;%PATH%

--- a/installChangeLog.bat
+++ b/installChangeLog.bat
@@ -4,5 +4,5 @@ setlocal
 
 call %~dp0env-set.bat
 
-gem install github_changelog_generator
+gem install github_changelog_generator --version 1.15.0.pre.rc
 endlocal

--- a/installChangeLog.bat
+++ b/installChangeLog.bat
@@ -4,5 +4,5 @@ setlocal
 
 call %~dp0env-set.bat
 
-gem install github_changelog_generator --version 1.15.0.pre.rc
+gem install github_changelog_generator --version 1.15.0.pre.beta
 endlocal

--- a/makeChangeLog.bat
+++ b/makeChangeLog.bat
@@ -4,10 +4,18 @@ setlocal
 
 call %~dp0env-set.bat
 
+REM 日本語を扱えるように内部エンコーディングを UTF-8 にする
+set RUBYOPT=-EUTF-8:UTF-8
+
 set ACCOUNTNAME=sakura-editor
 set PROJECTNAME=sakura
 set OUTFILENAME=CHANGELOG.md
 set EXCLUDELABELS=duplicate,question,invalid,wontfix,CI,management,refactoring
+set BUG_LABEL=### バグ修正
+set ENHANCEMENT_LABEL=### 機能追加
+set BREAKING_LABEL=### 仕様変更
+set BREAKING_LABELS="specification change"
+set PR_LABEL=### その他変更
 
 @echo.
 @echo INFO: APPVEYOR_REPO_NAME                   = %APPVEYOR_REPO_NAME%
@@ -38,11 +46,21 @@ if not defined CHANGELOG_GITHUB_TOKEN (
 	exit /b 1
 )
 
+REM
+REM 日本語を含むパラメータを指定すると文字化けするのでファイル経由で渡す
+REM
+echo bugs-label=%BUG_LABEL%                >  .github_changelog_generator
+echo enhancement-label=%ENHANCEMENT_LABEL% >> .github_changelog_generator
+echo breaking-label=%BREAKING_LABEL%       >> .github_changelog_generator
+echo pr-label=%PR_LABEL%                   >> .github_changelog_generator
+
 github_changelog_generator                           ^
 	-u %ACCOUNTNAME%                                 ^
 	-p %PROJECTNAME%                                 ^
 	-o %OUTFILENAME%                                 ^
 	--exclude-labels %EXCLUDELABELS%                 ^
+	--breaking-labels %BREAKING_LABELS%              ^
 	--cache-file %TEMP%\github-changelog-http-cache  ^
 	--cache-log  %TEMP%\github-changelog-logger.log
+
 endlocal

--- a/makeChangeLog.bat
+++ b/makeChangeLog.bat
@@ -11,11 +11,7 @@ set ACCOUNTNAME=sakura-editor
 set PROJECTNAME=sakura
 set OUTFILENAME=CHANGELOG.md
 set EXCLUDELABELS=duplicate,question,invalid,wontfix,CI,management,refactoring
-set BUG_LABEL=### バグ修正
-set ENHANCEMENT_LABEL=### 機能追加
-set BREAKING_LABEL=### 仕様変更
 set BREAKING_LABELS="specification change"
-set PR_LABEL=### その他変更
 
 @echo.
 @echo INFO: APPVEYOR_REPO_NAME                   = %APPVEYOR_REPO_NAME%
@@ -45,14 +41,6 @@ if not defined CHANGELOG_GITHUB_TOKEN (
 	endlocal
 	exit /b 1
 )
-
-REM
-REM 日本語を含むパラメータを指定すると文字化けするのでファイル経由で渡す
-REM
-echo bugs-label=%BUG_LABEL%                >  .github_changelog_generator
-echo enhancement-label=%ENHANCEMENT_LABEL% >> .github_changelog_generator
-echo breaking-label=%BREAKING_LABEL%       >> .github_changelog_generator
-echo pr-label=%PR_LABEL%                   >> .github_changelog_generator
 
 github_changelog_generator                           ^
 	-u %ACCOUNTNAME%                                 ^


### PR DESCRIPTION
- `github_changelog_generator` の v1.15.0.pre.beta で追加された `breaking-changes` オプションを使い、`specification change` ラベルが付いた PR/Issue を「仕様変更」として抽出するようにしました。

- 分類が英語だと分かりにくかったので [従来の変更履歴](https://sakura-editor.github.io/help/HLP_UR017.html) に合わせて「機能追加」「仕様変更」「バグ修正」「その他変更」として出力されるようにしました。


- 実行結果
  - AppVeyor: https://ci.appveyor.com/project/takke/changelog-sakura-djw7o/builds/20989124
  - 生成されたCHANGELOG.md: https://gist.github.com/takke/bd43164aa42d3d8d17b908dbfff67bce
