### PR TITLE
issue を除外した CHANGELOG_without_issues.md を生成する

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,3 +15,4 @@ build_script:
 
 artifacts:
   - path: 'CHANGELOG.md'
+  - path: 'CHANGELOG_without_issues.md'

--- a/makeChangeLog.bat
+++ b/makeChangeLog.bat
@@ -58,6 +58,6 @@ call github_changelog_generator                      ^
 REM issues を除外する
 REM (github_changelog_generator の --no-issues ではカテゴリ分類が消えるため)
 
-perl -pe "s/^-.*?[^)]\)\n//g; s/\*\*Closed issues:\*\*\n//g;" %OUTFILENAME% > %OUTFILENAME_WITHOUT_ISSUES%
+perl -pe "{binmode(STDOUT)} s/^-.*\/issues\/\d+\)\n//g; s/\*\*Closed issues:\*\*\n//g;" %OUTFILENAME% > %OUTFILENAME_WITHOUT_ISSUES%
 
 endlocal

--- a/makeChangeLog.bat
+++ b/makeChangeLog.bat
@@ -10,6 +10,7 @@ set RUBYOPT=-EUTF-8:UTF-8
 set ACCOUNTNAME=sakura-editor
 set PROJECTNAME=sakura
 set OUTFILENAME=CHANGELOG.md
+set OUTFILENAME_WITHOUT_ISSUES=CHANGELOG_without_issues.md
 set EXCLUDELABELS=duplicate,question,invalid,wontfix,CI,management,refactoring,no-changelog
 set BREAKING_LABELS="specification change"
 
@@ -42,7 +43,7 @@ if not defined CHANGELOG_GITHUB_TOKEN (
 	exit /b 1
 )
 
-github_changelog_generator                           ^
+call github_changelog_generator                      ^
 	-u %ACCOUNTNAME%                                 ^
 	-p %PROJECTNAME%                                 ^
 	-o %OUTFILENAME%                                 ^
@@ -50,5 +51,13 @@ github_changelog_generator                           ^
 	--breaking-labels %BREAKING_LABELS%              ^
 	--cache-file %TEMP%\github-changelog-http-cache  ^
 	--cache-log  %TEMP%\github-changelog-logger.log
+
+@echo.
+@echo filter issues
+@echo.
+REM issues を除外する
+REM (github_changelog_generator の --no-issues ではカテゴリ分類が消えるため)
+
+perl -pe "s/^-.*?[^)]\)\n//g; s/\*\*Closed issues:\*\*\n//g;" %OUTFILENAME% > %OUTFILENAME_WITHOUT_ISSUES%
 
 endlocal

--- a/makeChangeLog.bat
+++ b/makeChangeLog.bat
@@ -50,7 +50,7 @@ call github_changelog_generator                      ^
 	--exclude-labels %EXCLUDELABELS%                 ^
 	--breaking-labels %BREAKING_LABELS%              ^
 	--cache-file %TEMP%\github-changelog-http-cache  ^
-	--cache-log  %TEMP%\github-changelog-logger.log
+	--cache-log  %TEMP%\github-changelog-logger.log  || (echo error run github_changelog_generator && exit /b 1)
 
 @echo.
 @echo filter issues


### PR DESCRIPTION
当初は #22 で試されているように --no-issues, --no-issues-wo-labels でできると思っていたんですが、カテゴリ分類がなくなるなど実用に耐えないため、諦めていました。

とはいえ毎回、CHANGELOG.md をサクラエディタで開いて正規表現で消すのもしんどくなってきたので、sed 相当のコード(perl)で削除したファイルを生成するようにしてみました。

CHANGELOG.md 自体はそのまま残しています。

appveyor での実行結果：https://ci.appveyor.com/project/takke/changelog-sakura-djw7o/build/artifacts

よろしくお願いします。