### PR TITLE
Exclude doxygen label

### DIFF
--- a/makeChangeLog.bat
+++ b/makeChangeLog.bat
@@ -10,7 +10,7 @@ set RUBYOPT=-EUTF-8:UTF-8
 set ACCOUNTNAME=sakura-editor
 set PROJECTNAME=sakura
 set OUTFILENAME=CHANGELOG.md
-set EXCLUDELABELS=duplicate,question,invalid,wontfix,CI,management,refactoring
+set EXCLUDELABELS=duplicate,question,invalid,wontfix,CI,management,refactoring,doxygen
 set BREAKING_LABELS="specification change"
 
 @echo.


### PR DESCRIPTION
[doxygen 関連の生成ファイルを git から除外する by m\-tmatma · Pull Request \#831 · sakura\-editor/sakura](https://github.com/sakura-editor/sakura/pull/831) は CHANGELOG.md から除外してもいいかな、と思いましたので。

メモ：本PRマージ後にラベル説明に「doxygen関連【ChangeLog除外】」と記載する https://github.com/sakura-editor/sakura/issues/labels