### PR TITLE
除外用の no-changelog ラベルを追加

### DIFF
--- a/makeChangeLog.bat
+++ b/makeChangeLog.bat
@@ -10,7 +10,7 @@ set RUBYOPT=-EUTF-8:UTF-8
 set ACCOUNTNAME=sakura-editor
 set PROJECTNAME=sakura
 set OUTFILENAME=CHANGELOG.md
-set EXCLUDELABELS=duplicate,question,invalid,wontfix,CI,management,refactoring
+set EXCLUDELABELS=duplicate,question,invalid,wontfix,CI,management,refactoring,no-changelog
 set BREAKING_LABELS="specification change"
 
 @echo.


### PR DESCRIPTION
https://github.com/sakura-editor/changelog-sakura/pull/24 では `doxygen` ラベルを除外しようとしていましたが汎用的に「除外」するためのラベルを追加します。

https://github.com/sakura-editor/management-forum/issues/53#issuecomment-446057805 にも記載した通り、`no-issues` オプションがうまく機能しないバグの workaround としても `no-changelog` ラベルが紹介されていました。