### PR TITLE
faradayのバージョンを固定する

### DIFF
--- a/installChangeLog.bat
+++ b/installChangeLog.bat
@@ -4,5 +4,9 @@ setlocal
 
 call %~dp0env-set.bat
 
-gem install github_changelog_generator --version 1.15.0.pre.beta
+REM faraday 0.16 でエラーが発生するのでバージョンを固定する
+REM https://github.com/sakura-editor/changelog-sakura/issues/26
+call gem install faraday --version 0.15.4
+
+call gem install github_changelog_generator --version 1.15.0.pre.beta
 endlocal


### PR DESCRIPTION
依存先 gem の faraday を自動インストールすると 0.16.2 が入るがエラーが発生する。

本来は faraday 側または github_changelog_generator 側の修正を待つべきですが、workaround として本PRでは実績のある 0.15.4 に固定します。

fix #26 