### PR TITLE
バグ修正のラベルに "🐛bug🦋" を追加する

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -2,3 +2,4 @@ bugs-label=### バグ修正
 enhancement-label=### 機能追加
 breaking-label=### 仕様変更
 pr-label=### その他変更
+bug-labels=bug,Bug,🐛bug🦋


### PR DESCRIPTION
サクラエディタプロジェクトのバグ修正のラベルが `bug` -> `🐛bug🦋` に変わっていて「バグ修正」カテゴリが消えてしまっていたので `🐛bug🦋` を「バグ修正」とみなすように設定を追加する。

fix #28 