### PR TITLE
specify --no-filter-by-milestone option

### DIFF
--- a/makeChangeLog.bat
+++ b/makeChangeLog.bat
@@ -49,6 +49,7 @@ call github_changelog_generator                      ^
 	-o %OUTFILENAME%                                 ^
 	--exclude-labels %EXCLUDELABELS%                 ^
 	--breaking-labels %BREAKING_LABELS%              ^
+	--no-filter-by-milestone                         ^
 	--cache-file %TEMP%\github-changelog-http-cache  ^
 	--cache-log  %TEMP%\github-changelog-logger.log  || (echo error run github_changelog_generator && exit /b 1)
 


### PR DESCRIPTION
https://github.com/sakura-editor/sakura/pull/1232 で v2.4.0 に ChangeLog が出力される件の修正用です。

どうやら、`github_changelog_generator` はデフォルトだと「マイルストーン」単位で PR や Issue を紐付けるようです。v2.4.0 をリリースしたことでマイルストーンが出現し、それまでのように alpha/beta 版のリリースに PR 項目が出力されなくなってしまったようです。

というわけで、`--no-filter-by-milestone` オプションを追加し、マイルストーンに優先されないように変更しました。

出力結果は
https://ci.appveyor.com/project/takke/changelog-sakura-djw7o/builds/32712604/artifacts
にあるのでご確認ください。
