### PR TITLE
最新のラベル設定に合わせて EXCLUDELABELS を修正

### DIFF
--- a/makeChangeLog.bat
+++ b/makeChangeLog.bat
@@ -11,7 +11,7 @@ set ACCOUNTNAME=sakura-editor
 set PROJECTNAME=sakura
 set OUTFILENAME=CHANGELOG.md
 set OUTFILENAME_WITHOUT_ISSUES=CHANGELOG_without_issues.md
-set EXCLUDELABELS=duplicate,question,invalid,wontfix,CI,management,refactoring,no-changelog
+set EXCLUDELABELS=CI,CodeFactor,duplicate,environment,Git,management,no-changelog,question,refactoring,Release,research
 set BREAKING_LABELS="specification change"
 
 @echo.


### PR DESCRIPTION
[Labels · sakura\-editor/sakura](https://github.com/sakura-editor/sakura/labels) がいつの間にか変更されていたんですが、【ChangeLog除外】と書かれているラベルが実際の CHANGELOG.md 生成時の設定 (EXCLUDELABELS) に反映されていませんので修正しました。

EXCLUDELABELS の指定順はメンテしやすいように https://github.com/sakura-editor/sakura/labels の出現順とし、https://github.com/sakura-editor/sakura/labels に含まれていない invalid と wontfix は削除しました。

https://ci.appveyor.com/project/takke/changelog-sakura-djw7o/builds/32784104/artifacts の
https://ci.appveyor.com/api/buildjobs/lg3cn2pm1hjwkbp7/artifacts/CHANGELOG_without_issues.md を見ると Release タグが付いた https://github.com/sakura-editor/sakura/pull/1197 が出力されていないので大丈夫かと思います。
